### PR TITLE
Use `np.polynomial.chebyshev.chebroots` instead of `np.roots`

### DIFF
--- a/pina/chebyshev.py
+++ b/pina/chebyshev.py
@@ -1,6 +1,7 @@
-from mpmath import chebyt, chop, taylor
 import numpy as np
 def chebyshev_roots(n):
     """ Return the roots of *n* Chebyshev polynomials (between [-1, 1]) """
-    return np.roots(chop(taylor(lambda x: chebyt(n, x), 0, n))[::-1])
+    coefficents = np.zeros(n+1)
+    coefficents[-1] = 1
+    return np.polynomial.chebyshev.chebroots(coefficents)
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ VERSION = meta['__version__']
 KEYWORDS = 'physics-informed neural-network'
 
 REQUIRED = [
-    'future', 'numpy', 'matplotlib', 'torch', 'mpmath'
-    
+    'future', 'numpy', 'matplotlib', 'torch'  
 ]
 
 EXTRAS = {


### PR DESCRIPTION
An implementation which uses `np.polynomial.chebyshev.chebroots` looks more performant by 1 or 2 orders of magnitude:
![plot](https://user-images.githubusercontent.com/8464342/154370802-da7703f4-cacb-4a9f-8cbb-8b144a79e1c2.png)

However I do not know if the order of the roots is important, because it's **not** always the same. There are also some `1.e-16/17` instead of zeros.

Example:
```python
np.polynomial.chebyshev.chebroots() -> [ 9.51056516e-01  5.87785252e-01  7.37692017e-17 
        -5.87785252e-01 -9.51056516e-01] 
np.roots() -> [-0.95105652 -0.58778525  0.95105652  0.58778525  0. ]
```