### PR TITLE
Adding features to label tensor class

### DIFF
--- a/pina/label_tensor.py
+++ b/pina/label_tensor.py
@@ -68,15 +68,6 @@ class LabelTensor(torch.Tensor):
             )
         self._labels = labels
 
-    def _exist_labels(self):
-        """Check the existence of labels in a label tensor
-
-        :return: True if the tensor label exists, False otherwise
-        :rtype: bool
-        """
-        test = hasattr(self, 'labels')
-        return bool(test)
-
     @property
     def labels(self):
         """Property decorator for labels
@@ -88,11 +79,10 @@ class LabelTensor(torch.Tensor):
 
     @labels.setter
     def labels(self, labels):
-        if not self._exist_labels():  # if labels dont not exist for self
-            if len(labels) != self.shape[1]:
-                raise ValueError(
-                    'the tensor has not the same number of columns of '
-                    'the passed labels.')
+        if len(labels) != self.shape[1]: # small check
+            raise ValueError(
+                'the tensor has not the same number of columns of '
+                'the passed labels.')
 
         self._labels = labels   # assign the label
 

--- a/pina/label_tensor.py
+++ b/pina/label_tensor.py
@@ -66,7 +66,33 @@ class LabelTensor(torch.Tensor):
                 'the tensor has not the same number of columns of '
                 'the passed labels.'
             )
-        self.labels = labels
+        self._labels = labels
+
+    def _exist_labels(self):
+        """Check the existence of labels in a label tensor
+
+        :return: Returns True if the tensor has already
+        a label, False otherwise
+        :rtype: bool
+        """
+        if hasattr(self, 'labels'):
+            return True
+        else:
+            return False
+
+    @property
+    def labels(self):
+        return self._labels
+
+    @labels.setter
+    def labels(self, labels):
+        if not self._exist_labels():  # if a label does not exist for current tensor
+            if len(labels) != self.shape[1]:
+                raise ValueError(
+                    'the tensor has not the same number of columns of '
+                    'the passed labels.')
+
+            self._labels = labels   # assign the label
 
     def clone(self, *args, **kwargs):
         """
@@ -115,11 +141,10 @@ class LabelTensor(torch.Tensor):
                 raise ValueError(f'`{f}` not in the labels list')
 
         new_data = self[:, indeces].float()
-        new_labels = [self.labels[idx] for idx in indeces]
+        labelss = [self.labels[idx] for idx in indeces]
 
         extracted_tensor = new_data.as_subclass(LabelTensor)
-        extracted_tensor.labels = new_labels
-
+        extracted_tensor.labels = labelss
 
         return extracted_tensor
 
@@ -135,7 +160,7 @@ class LabelTensor(torch.Tensor):
         if set(self.labels).intersection(lt.labels):
             raise RuntimeError('The tensors to merge have common labels')
 
-        new_labels = self.labels + lt.labels
+        labelss = self.labels + lt.labels
         if mode == 'std':
             new_tensor = torch.cat((self, lt), dim=1)
         elif mode == 'first':
@@ -155,7 +180,7 @@ class LabelTensor(torch.Tensor):
             new_tensor = torch.cat((tensor1, tensor2), dim=1)
 
         new_tensor = new_tensor.as_subclass(LabelTensor)
-        new_tensor.labels = new_labels
+        new_tensor.labels = labelss
         return new_tensor
 
     def __str__(self):

--- a/pina/label_tensor.py
+++ b/pina/label_tensor.py
@@ -92,7 +92,7 @@ class LabelTensor(torch.Tensor):
                     'the tensor has not the same number of columns of '
                     'the passed labels.')
 
-            self._labels = labels   # assign the label
+        self._labels = labels   # assign the label
 
     def clone(self, *args, **kwargs):
         """

--- a/pina/label_tensor.py
+++ b/pina/label_tensor.py
@@ -75,18 +75,21 @@ class LabelTensor(torch.Tensor):
         a label, False otherwise
         :rtype: bool
         """
-        if hasattr(self, 'labels'):
-            return True
-        else:
-            return False
+        test = hasattr(self, 'labels')
+        return bool(test)
 
     @property
     def labels(self):
+        """Property decorator for labels
+
+        :return: labels of self
+        :rtype: list
+        """
         return self._labels
 
     @labels.setter
     def labels(self, labels):
-        if not self._exist_labels():  # if a label does not exist for current tensor
+        if not self._exist_labels():  # if labels dont not exist for self
             if len(labels) != self.shape[1]:
                 raise ValueError(
                     'the tensor has not the same number of columns of '
@@ -141,10 +144,10 @@ class LabelTensor(torch.Tensor):
                 raise ValueError(f'`{f}` not in the labels list')
 
         new_data = self[:, indeces].float()
-        labelss = [self.labels[idx] for idx in indeces]
+        new_labels = [self.labels[idx] for idx in indeces]
 
         extracted_tensor = new_data.as_subclass(LabelTensor)
-        extracted_tensor.labels = labelss
+        extracted_tensor.labels = new_labels
 
         return extracted_tensor
 
@@ -160,7 +163,7 @@ class LabelTensor(torch.Tensor):
         if set(self.labels).intersection(lt.labels):
             raise RuntimeError('The tensors to merge have common labels')
 
-        labelss = self.labels + lt.labels
+        new_labels = self.labels + lt.labels
         if mode == 'std':
             new_tensor = torch.cat((self, lt), dim=1)
         elif mode == 'first':
@@ -180,7 +183,7 @@ class LabelTensor(torch.Tensor):
             new_tensor = torch.cat((tensor1, tensor2), dim=1)
 
         new_tensor = new_tensor.as_subclass(LabelTensor)
-        new_tensor.labels = labelss
+        new_tensor.labels = new_labels
         return new_tensor
 
     def __str__(self):

--- a/pina/label_tensor.py
+++ b/pina/label_tensor.py
@@ -71,8 +71,7 @@ class LabelTensor(torch.Tensor):
     def _exist_labels(self):
         """Check the existence of labels in a label tensor
 
-        :return: Returns True if the tensor has already
-        a label, False otherwise
+        :return: True if the tensor label exists, False otherwise
         :rtype: bool
         """
         test = hasattr(self, 'labels')

--- a/tests/test_label_tensor.py
+++ b/tests/test_label_tensor.py
@@ -20,6 +20,8 @@ def test_labels():
     tensor = LabelTensor(data, labels)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.labels == labels
+    with pytest.raises(ValueError):
+        tensor.labels = labels[:-1]
 
 
 def test_extract():


### PR DESCRIPTION
Please consider this pull request for bug fixing. 

Consider the following example:
```
x = torch.rand((10, 2))    # create a tensor with two columns
variables  = ['u']              # create one variable
output = x.as_subclass(LabelTensor)   # x tensor points at LabelTensor class, and it is assigned to ouput
output.labels = variables                        # output labels are assigned
```
Notice that output is now an incorrect label tensor (two columns but only one is labelled). This can be avoided by adding a setter decorator on labels. This first checks the existence of a label in a label tensor, and if the tensor does not have a label we assign a new label (after testing compatibility of columns number and labels number).