### PR TITLE
add train/eval

### DIFF
--- a/pina/pinn.py
+++ b/pina/pinn.py
@@ -213,6 +213,7 @@ class PINN(object):
 
     def train(self, stop=100, frequency_print=2, save_loss=1, trial=None):
 
+        self.model.train()
         epoch = 0
         data_loader = self.data_set.dataloader
 
@@ -304,6 +305,8 @@ class PINN(object):
 
             self.trained_epoch += 1
             epoch += 1
+
+        self.model.eval()
 
         return sum(losses).item()
 


### PR DESCRIPTION
Add the `.train()` and `.eval()` method to set the PINA model in train/eval mode. This feature is especially useful for some particular torch modules (Dropout, BatchNorm), see [code](https://pytorch.org/docs/stable/_modules/torch/nn/modules/module.html#Module.train).