### PR TITLE
Label Tensor update

### DIFF
--- a/pina/label_tensor.py
+++ b/pina/label_tensor.py
@@ -132,20 +132,22 @@ class LabelTensor(torch.Tensor):
         return tmp
 
     def cuda(self, *args, **kwargs):
-            """
-            Send Tensor to cuda. For more details, see :meth:`torch.Tensor.cuda`.
-            """
-            tmp = super().cuda(*args, **kwargs)
-            tmp._labels = self._labels
-            return tmp
+        """
+        Send Tensor to cuda. For more details, see :meth:`torch.Tensor.cuda`.
+        """
+        tmp = super().cuda(*args, **kwargs)
+        new = self.__class__.clone(self)
+        new.data = tmp.data
+        return tmp
 
     def cpu(self, *args, **kwargs):
-            """
-            Send Tensor to cpu. For more details, see :meth:`torch.Tensor.cpu`.
-            """
-            tmp = super().cpu(*args, **kwargs)
-            tmp._labels = self._labels
-            return tmp
+        """
+        Send Tensor to cpu. For more details, see :meth:`torch.Tensor.cpu`.
+        """
+        tmp = super().cpu(*args, **kwargs)
+        new = self.__class__.clone(self)
+        new.data = tmp.data
+        return tmp
 
     def extract(self, label_to_extract):
         """

--- a/tests/test_label_tensor.py
+++ b/tests/test_label_tensor.py
@@ -87,6 +87,11 @@ def test_getitem():
     assert tensor_view.labels == ['a']
     assert torch.allclose(tensor_view.flatten(), data[:, 0])
 
+    tensor_view = tensor['a', 'c']
+
+    assert tensor_view.labels == ['a', 'c']
+    assert torch.allclose(tensor_view, data[:, 0::2])
+
 def test_getitem2():
     tensor = LabelTensor(data, labels)
     tensor_view = tensor[:5]

--- a/tests/test_label_tensor.py
+++ b/tests/test_label_tensor.py
@@ -27,7 +27,6 @@ def test_labels():
 def test_extract():
     label_to_extract = ['a', 'c']
     tensor = LabelTensor(data, labels)
-    print(tensor)
     new = tensor.extract(label_to_extract)
     assert new.labels == label_to_extract
     assert new.shape[1] == len(label_to_extract)
@@ -58,7 +57,6 @@ def test_extract_order():
     expected = torch.cat(
         (data[:, 2].reshape(-1, 1), data[:, 0].reshape(-1, 1)),
         dim=1)
-    print(expected)
     assert new.labels == label_to_extract
     assert new.shape[1] == len(label_to_extract)
     assert torch.all(torch.isclose(expected, new))
@@ -83,6 +81,13 @@ def test_merge2():
 
 
 def test_getitem():
+    tensor = LabelTensor(data, labels)
+    tensor_view = tensor['a']
+
+    assert tensor_view.labels == ['a']
+    assert torch.allclose(tensor_view.flatten(), data[:, 0])
+
+def test_getitem2():
     tensor = LabelTensor(data, labels)
     tensor_view = tensor[:5]
 


### PR DESCRIPTION
Updating `LabelTensor` class. Now passing to cuda/cpu and changing dtype is supported in `LabelTensor`. Additionally, we added the possibility to slice the tensor as:
```

labels = ['a', 'b']
data = torch.rand((10, 2))
tensor = LabelTensor(data, labels)
tensor_view = tensor['a']            # same as tensor.extract('a')
```