### PR TITLE
fix : gpu loss plotting

### DIFF
--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -256,7 +256,7 @@ class Plotter:
                 )
             loss = trainer_metrics[metric]
             epochs = range(len(loss))
-            plt.plot(epochs, loss, **kwargs)
+            plt.plot(epochs, loss.cpu(), **kwargs)
 
         # plotting
         plt.xlabel('epoch')


### PR DESCRIPTION
Hey guys

As numpy doesn't support GPU yet, I found a way to fix the bug I mentioned in [https://github.com/mathLab/PINA/issues/219](url), using `plt.plot(epochs, loss.cpu(), **kwargs)` instead of `plt.plot(epochs, loss, **kwargs)`


I have tested these changes locally, but I would greatly appreciate it if you could review and provide feedback on the solution I used. 