### PR TITLE
fix : check_components_type

### DIFF
--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -176,6 +176,9 @@ class Plotter:
         if components is None:
             components = solver.problem.output_variables
         
+        if type(components) is not list:
+            components = [components]
+            
         if len(components) > 1:
             raise NotImplementedError('Multidimensional plots are not implemented, '
                                       'set components to an available components of the problem.')

--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -160,7 +160,7 @@ class Plotter:
         :param SolverInterface solver: The ``SolverInterface`` object instance.
         :param components: The output variable or variables to plot. If None, all
                   the output variables of the problem are selected. Can be a
-                  single string or a list of strings. Default value is None.
+                  single string or a string list. Default value is None.
         :param dict fixed_variables: A dictionary with all the variables that
             should be kept fixed during the plot. The keys of the dictionary
             are the variables name whereas the values are the corresponding
@@ -181,7 +181,8 @@ class Plotter:
             components = [components]
 
         if not isinstance(components, list):
-            raise NotImplementedError('Output variables must be passed as a string or a list of strings.')
+            raise NotImplementedError('Output variables must be passed'
+                                       'as a string or a list of strings.')
         
         if len(components) > 1:
             raise NotImplementedError('Multidimensional plots are not implemented, '

--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -176,7 +176,7 @@ class Plotter:
         if components is None:
             components = solver.problem.output_variables
         
-        if type(components) is not list:
+        if isinstance(components, str):
             components = [components]
             
         if len(components) > 1:

--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -158,8 +158,9 @@ class Plotter:
         Plot sample of SolverInterface output.
 
         :param SolverInterface solver: The ``SolverInterface`` object instance.
-        :param str | list(str) components: The output variable(s) to plot. If None, all
-            the output variables of the problem are selected. Default value is None.
+        :param str | list(str) components: The output variable(s) to plot. 
+            If None, all the output variables of the problem are selected. 
+            Default value is None.
         :param dict fixed_variables: A dictionary with all the variables that
             should be kept fixed during the plot. The keys of the dictionary
             are the variables name whereas the values are the corresponding

--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -158,9 +158,8 @@ class Plotter:
         Plot sample of SolverInterface output.
 
         :param SolverInterface solver: The ``SolverInterface`` object instance.
-        :param components: The output variable or variables to plot. If None, all
-                  the output variables of the problem are selected. Can be a
-                  single string or a string list. Default value is None.
+        :param str | list(str) components: The output variable(s) to plot. If None, all
+            the output variables of the problem are selected. Default value is None.
         :param dict fixed_variables: A dictionary with all the variables that
             should be kept fixed during the plot. The keys of the dictionary
             are the variables name whereas the values are the corresponding

--- a/pina/plotter.py
+++ b/pina/plotter.py
@@ -158,8 +158,9 @@ class Plotter:
         Plot sample of SolverInterface output.
 
         :param SolverInterface solver: The ``SolverInterface`` object instance.
-        :param list(str) components: The output variable to plot. If None, all
-            the output variables of the problem are selected. Default value is None.
+        :param components: The output variable or variables to plot. If None, all
+                  the output variables of the problem are selected. Can be a
+                  single string or a list of strings. Default value is None.
         :param dict fixed_variables: A dictionary with all the variables that
             should be kept fixed during the plot. The keys of the dictionary
             are the variables name whereas the values are the corresponding
@@ -178,7 +179,10 @@ class Plotter:
         
         if isinstance(components, str):
             components = [components]
-            
+
+        if not isinstance(components, list):
+            raise NotImplementedError('Output variables must be passed as a string or a list of strings.')
+        
         if len(components) > 1:
             raise NotImplementedError('Multidimensional plots are not implemented, '
                                       'set components to an available components of the problem.')


### PR DESCRIPTION
Good afternoon,
I found a small bug on the plotter.plot function :

## The bug 

When plotting a function and selecting a single component, like this : 

```python
plotter.plot(pinn,components = 'x1' , fixed_variables = ...)
```
if the variable name is longer than 1 character, an error is thrown because the function expects a list and gets a string, therefore counting the number of characters in it. 

## The solution 

I added a simple check : 

```python
if type(components) is not list:
     components = [components]
```
I have tested these changes locally, but I would greatly appreciate it if you could review and provide feedback on the solution I used.