### PR TITLE
Update system_equation.py

### DIFF
--- a/pina/equation/system_equation.py
+++ b/pina/equation/system_equation.py
@@ -7,7 +7,7 @@ from ..utils import check_consistency
 
 class SystemEquation(Equation):
 
-    def __init__(self, list_equation, reduction="None"):
+    def __init__(self, list_equation, reduction=None):
         """
         System of Equation class for specifing any system
         of equations in PINA.
@@ -38,7 +38,7 @@ class SystemEquation(Equation):
             self.reduction = torch.mean
         elif reduction == "sum":
             self.reduction = torch.sum
-        elif (reduction == "None") or callable(reduction):
+        elif (reduction == None) or callable(reduction):
             self.reduction = reduction
         else:
             raise NotImplementedError(
@@ -72,7 +72,7 @@ class SystemEquation(Equation):
             ]
         )
 
-        if self.reduction == "None":
+        if self.reduction is None:
             return residual
 
         return self.reduction(residual, dim=-1)

--- a/pina/equation/system_equation.py
+++ b/pina/equation/system_equation.py
@@ -7,7 +7,7 @@ from ..utils import check_consistency
 
 class SystemEquation(Equation):
 
-    def __init__(self, list_equation, reduction="none"):
+    def __init__(self, list_equation, reduction="None"):
         """
         System of Equation class for specifing any system
         of equations in PINA.
@@ -38,7 +38,7 @@ class SystemEquation(Equation):
             self.reduction = torch.mean
         elif reduction == "sum":
             self.reduction = torch.sum
-        elif (reduction == "none") or callable(reduction):
+        elif (reduction == "None") or callable(reduction):
             self.reduction = reduction
         else:
             raise NotImplementedError(
@@ -72,7 +72,7 @@ class SystemEquation(Equation):
             ]
         )
 
-        if self.reduction == "none":
+        if self.reduction == "None":
             return residual
 
         return self.reduction(residual, dim=-1)

--- a/pina/equation/system_equation.py
+++ b/pina/equation/system_equation.py
@@ -7,7 +7,7 @@ from ..utils import check_consistency
 
 class SystemEquation(Equation):
 
-    def __init__(self, list_equation, reduction="mean"):
+    def __init__(self, list_equation, reduction="none"):
         """
         System of Equation class for specifing any system
         of equations in PINA.

--- a/pina/equation/system_equation.py
+++ b/pina/equation/system_equation.py
@@ -26,7 +26,6 @@ class SystemEquation(Equation):
             no checks guaranteed. Default: None.
         """
         check_consistency([list_equation], list)
-        check_consistency(reduction, str)
 
         # equations definition
         self.equations = []

--- a/pina/equation/system_equation.py
+++ b/pina/equation/system_equation.py
@@ -19,11 +19,11 @@ class SystemEquation(Equation):
         :param Callable equation: A ``torch`` callable equation to
             evaluate the residual
         :param str reduction: Specifies the reduction to apply to the output:
-            ``none`` | ``mean`` | ``sum``  | ``callable``. ``none``: no reduction
-            will be applied, ``mean``: the sum of the output will be divided
+            None | ``mean`` | ``sum``  | callable. None: no reduction
+            will be applied, ``mean``: the output sum will be divided
             by the number of elements in the output, ``sum``: the output will
-            be summed. ``callable`` a callable function to perform reduction,
-            no checks guaranteed. Default: ``mean``.
+            be summed. *callable* is a callable function to perform reduction,
+            no checks guaranteed. Default: None.
         """
         check_consistency([list_equation], list)
         check_consistency(reduction, str)

--- a/tests/test_equations/test_systemequation.py
+++ b/tests/test_equations/test_systemequation.py
@@ -39,7 +39,7 @@ def test_residual():
     u = torch.pow(pts, 2)
     u.labels = ['u1', 'u2']
 
-    eq_1 = SystemEquation([eq1, eq2])
+    eq_1 = SystemEquation([eq1, eq2], reduction = 'mean')
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10])
 
@@ -50,3 +50,7 @@ def test_residual():
     eq_1 = SystemEquation([eq1, eq2], reduction='none')
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10, 3])
+
+    eq_1 = SystemEquation([eq1, eq2])
+    res = eq_1.residual(pts, u)
+    assert res.shape == torch.Size([10])

--- a/tests/test_equations/test_systemequation.py
+++ b/tests/test_equations/test_systemequation.py
@@ -39,7 +39,7 @@ def test_residual():
     u = torch.pow(pts, 2)
     u.labels = ['u1', 'u2']
 
-    eq_1 = SystemEquation([eq1, eq2], reduction = 'mean')
+    eq_1 = SystemEquation([eq1, eq2], reduction='mean')
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10])
 
@@ -47,7 +47,7 @@ def test_residual():
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10])
 
-    eq_1 = SystemEquation([eq1, eq2], reduction='None')
+    eq_1 = SystemEquation([eq1, eq2], reduction=None)
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10, 3])
 

--- a/tests/test_equations/test_systemequation.py
+++ b/tests/test_equations/test_systemequation.py
@@ -47,7 +47,7 @@ def test_residual():
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10])
 
-    eq_1 = SystemEquation([eq1, eq2], reduction='none')
+    eq_1 = SystemEquation([eq1, eq2], reduction='None')
     res = eq_1.residual(pts, u)
     assert res.shape == torch.Size([10, 3])
 

--- a/tests/test_equations/test_systemequation.py
+++ b/tests/test_equations/test_systemequation.py
@@ -53,4 +53,4 @@ def test_residual():
 
     eq_1 = SystemEquation([eq1, eq2])
     res = eq_1.residual(pts, u)
-    assert res.shape == torch.Size([10])
+    assert res.shape == torch.Size([10, 3])


### PR DESCRIPTION
When using 'mean' the residual of the system of equation is created making the mean of all the equation residuals listed in SystemEquation. 

When using 'sum', the residuals of the equations are summed, the norm is computed and then divided by the number of equations.

None of the above procedures are the most intuitive and correct way of computing the residual of a system of equations. The correct standard procedure should be "none" which evaluates the norm of the residuals then it computes the mean between them. 