### PR TITLE
NTK weighting

### DIFF
--- a/pina/loss/weighted_aggregation.py
+++ b/pina/loss/weighted_aggregation.py
@@ -1,7 +1,8 @@
 """ Module for Loss Interface """
 
 from .weightning_interface import weightningInterface
-
+from torch import norm
+from pina.operators import grad
 
 class WeightedAggregation(WeightningInterface):
     """
@@ -33,3 +34,37 @@ class WeightedAggregation(WeightningInterface):
             return sum(weighted_losses.values())
         else:
             raise ValueError(self.aggr + " is not valid for aggregation.")
+
+
+    def NTK_weighting(self, losses, alpha = 0.5):
+        """
+        Weights the losses according to the Neural Tangent Kernel 
+
+        :param dict(torch.Tensor) input: The dictionary of losses.
+        :param alpha(float) input: The parameter alpha that regulates the moving average
+        between old and new weights. 
+        :return: The losses aggregation. It should be a scalar Tensor.
+        :rtype: torch.Tensor
+
+        Reference:
+        Wang, S., Sankaran, S., Wang, H., & Perdikaris, P. (2023). 
+        An expert's guide to training physics-informed neural networks. 
+        arXiv preprint arXiv:2308.08468.
+        """
+        self.aggr = 'sum'
+
+        if self.weights:
+            
+            losses_norm = {
+                condition: norm(grad(losses[condition])) for condition in losses
+            }
+            self.weights = {
+                condition: alpha* self.weights[condition] + 
+                (1- alpha)*losses_norm[condition]/sum(losses_norm.values())
+                for condition in losses
+            }
+            
+        else: 
+            self.weights = {
+                condition: 1 for condition in losses}
+        return self.aggregate(losses)

--- a/pina/loss/weightning_interface.py
+++ b/pina/loss/weightning_interface.py
@@ -22,3 +22,10 @@ class weightningInterface(metaclass=ABCMeta):
         :rtype: torch.Tensor
         """
         pass
+
+    @abstractmethod
+    def NTK_weighting(self, losses):
+        """
+        Weight the losses 
+        """
+        pass


### PR DESCRIPTION
NTK weighting has been added in weights/weighted_aggregation.py. 
Things to check/modify:
- check how to access loss gradients w.r.t. weights 
- check if NTK weighting should be a method or a class
- check if weights/weighted_aggregation.py is the right place to put the method