### PR TITLE
Change SVD type in pod.py

### DIFF
--- a/pina/model/layers/pod.py
+++ b/pina/model/layers/pod.py
@@ -118,10 +118,7 @@ class PODBlock(torch.nn.Module):
 
         :param torch.Tensor X: The tensor to be reduced.
         """
-        if X.device.type == "mps":  #  svd_lowrank not arailable for mps
-            self._basis = torch.svd(X.T)[0].T
-        else:
-            self._basis = torch.svd_lowrank(X.T, q=X.shape[0])[0].T
+        self._basis = torch.svd(X.T)[0].T
 
     def forward(self, X):
         """

--- a/tests/test_layers/test_pod.py
+++ b/tests/test_layers/test_pod.py
@@ -25,9 +25,10 @@ def test_fit(rank, scale):
 
 @pytest.mark.parametrize("scale", [True, False])
 @pytest.mark.parametrize("rank", [1, 2, 10])
-def test_fit(rank, scale):
+@pytest.mark.parametrize("randomized", [True, False])
+def test_fit(rank, scale, randomized):
     pod = PODBlock(rank, scale)
-    pod.fit(toy_snapshots)
+    pod.fit(toy_snapshots, randomized)
     n_snap = toy_snapshots.shape[0]
     dof = toy_snapshots.shape[1]
     assert pod.basis.shape == (rank, dof)
@@ -65,18 +66,20 @@ def test_forward():
 
 @pytest.mark.parametrize("scale", [True, False])
 @pytest.mark.parametrize("rank", [1, 2, 10])
-def test_expand(rank, scale):
+@pytest.mark.parametrize("randomized", [True, False])
+def test_expand(rank, scale, randomized):
     pod = PODBlock(rank, scale)
-    pod.fit(toy_snapshots)
+    pod.fit(toy_snapshots, randomized)
     c = pod(toy_snapshots)
     torch.testing.assert_close(pod.expand(c), toy_snapshots)
     torch.testing.assert_close(pod.expand(c[0]), toy_snapshots[0].unsqueeze(0))
 
 @pytest.mark.parametrize("scale", [True, False])
 @pytest.mark.parametrize("rank", [1, 2, 10])
-def test_reduce_expand(rank, scale):
+@pytest.mark.parametrize("randomized", [True, False])
+def test_reduce_expand(rank, scale, randomized):
     pod = PODBlock(rank, scale)
-    pod.fit(toy_snapshots)
+    pod.fit(toy_snapshots, randomized)
     torch.testing.assert_close(
         pod.expand(pod.reduce(toy_snapshots)),
         toy_snapshots)


### PR DESCRIPTION
Only replaced the `torch.svd_lowrank` method with `torch.svd`: the reason is that `torch.svd_lowrank` is randomized and may give different results in different runs (as specified in the documentation: [https://pytorch.org/docs/stable/generated/torch.svd_lowrank.html](https://pytorch.org/docs/stable/generated/torch.svd_lowrank.html))