### PR TITLE
Bug fix and add additional tests for Dataset and DataModule

### DIFF
--- a/pina/data/dataset.py
+++ b/pina/data/dataset.py
@@ -167,9 +167,15 @@ class PinaDataset(Dataset, ABC):
         :return: A dictionary containing all the data in the dataset.
         :rtype: dict
         """
-
-        index = list(range(len(self)))
-        return self.fetch_from_idx_list(index)
+        to_return_dict = {}
+        for condition, data in self.conditions_dict.items():
+            len_condition = len(
+                data["input"]
+            )  # Length of the current condition
+            to_return_dict[condition] = self._retrive_data(
+                data, list(range(len_condition))
+            )  # Retrieve the data from the current condition
+        return to_return_dict
 
     def fetch_from_idx_list(self, idx):
         """
@@ -306,3 +312,13 @@ class PinaGraphDataset(PinaDataset):
             )
             for k, v in data.items()
         }
+
+    @property
+    def input(self):
+        """
+        Return the input data for the dataset.
+
+        :return: Dictionary containing the input points.
+        :rtype: dict
+        """
+        return {k: v["input"] for k, v in self.conditions_dict.items()}

--- a/tests/test_data/test_graph_dataset.py
+++ b/tests/test_data/test_graph_dataset.py
@@ -31,7 +31,7 @@ conditions_dict_single = {
 max_conditions_lengths_single = {"data": 100}
 
 # Problem with multiple conditions
-conditions_dict_single_multi = {
+conditions_dict_multi = {
     "data_1": {
         "input": input_,
         "target": output_,
@@ -49,7 +49,7 @@ max_conditions_lengths_multi = {"data_1": 100, "data_2": 50}
     "conditions_dict, max_conditions_lengths",
     [
         (conditions_dict_single, max_conditions_lengths_single),
-        (conditions_dict_single_multi, max_conditions_lengths_multi),
+        (conditions_dict_multi, max_conditions_lengths_multi),
     ],
 )
 def test_constructor(conditions_dict, max_conditions_lengths):
@@ -66,7 +66,7 @@ def test_constructor(conditions_dict, max_conditions_lengths):
     "conditions_dict, max_conditions_lengths",
     [
         (conditions_dict_single, max_conditions_lengths_single),
-        (conditions_dict_single_multi, max_conditions_lengths_multi),
+        (conditions_dict_multi, max_conditions_lengths_multi),
     ],
 )
 def test_getitem(conditions_dict, max_conditions_lengths):
@@ -110,3 +110,29 @@ def test_getitem(conditions_dict, max_conditions_lengths):
         ]
     )
     assert all([d["input"].edge_attr.shape[0] == 1200 for d in data.values()])
+
+
+def test_input_single_condition():
+    dataset = PinaDatasetFactory(
+        conditions_dict_single,
+        max_conditions_lengths=max_conditions_lengths_single,
+        automatic_batching=True,
+    )
+    input_ = dataset.input
+    assert isinstance(input_, dict)
+    assert isinstance(input_["data"], list)
+    assert all([isinstance(d, Data) for d in input_["data"]])
+
+
+def test_input_multi_condition():
+    dataset = PinaDatasetFactory(
+        conditions_dict_multi,
+        max_conditions_lengths=max_conditions_lengths_multi,
+        automatic_batching=True,
+    )
+    input_ = dataset.input
+    assert isinstance(input_, dict)
+    assert isinstance(input_["data_1"], list)
+    assert all([isinstance(d, Data) for d in input_["data_1"]])
+    assert isinstance(input_["data_2"], list)
+    assert all([isinstance(d, Data) for d in input_["data_2"]])


### PR DESCRIPTION
In this PR, I fix a bug in `get_all_data` function in Dataset. The code for reproducing the issue is the following
```python
input=torch.stack([torch.zeros((1,))+i for i in range(1000)])
target=input
problem = SupervisedProblem(input,target)
datamodule = PinaDataModule(problem,
        train_size=0.7,
        test_size=0.2,
        val_size=0.1,
        batch_size=64,
        shuffle=False,
        repeat=False,
        automatic_batching=None,
        num_workers=0,
        pin_memory=False,)
datamodule.setup('fit')
datamodule.setup('test')
print()
print('Using batch_size 64')
print(f'{(len(datamodule.train_dataset)==700)=}')
print(f'{(len(datamodule.test_dataset)==200)=}')
print(f'{(len(datamodule.val_dataset)==100)=}')
print()
print(f'{(len(datamodule.train_dataset.get_all_data()["data"]["input"])==700)=}')  # <==== False but must be True
print(f'{(len(datamodule.test_dataset.get_all_data()["data"]["input"])==200)=}')   # <==== False but must be True
print(f'{(len(datamodule.val_dataset.get_all_data()["data"]["input"])==100)=}')    # <==== False but must be True
```
Moreover, I remove a useless shuffle operation in `PinaDataModule` when creating the Dataloader (shuffle has already been performed). Finally, I improve the test of both dataset and datamodule classes. 