### PR TITLE
Add singular values in PODBlock

### DIFF
--- a/pina/model/block/pod_block.py
+++ b/pina/model/block/pod_block.py
@@ -163,7 +163,6 @@ class PODBlock(torch.nn.Module):
         self._basis = u.T
         self._singular_values = s
 
-
     def forward(self, X):
         """
         The forward pass of the POD layer.

--- a/pina/model/block/pod_block.py
+++ b/pina/model/block/pod_block.py
@@ -150,16 +150,16 @@ class PODBlock(torch.nn.Module):
                 "This may slow down computations.",
                 ResourceWarning,
             )
-            u, s, v = torch.svd(X.T)
+            u, s, _ = torch.svd(X.T)
         else:
             if randomized:
                 warnings.warn(
                     "Considering a randomized algorithm to compute the POD basis"
                 )
-                u, s, v = torch.svd_lowrank(X.T, q=X.shape[0])
+                u, s, _ = torch.svd_lowrank(X.T, q=X.shape[0])
 
             else:
-                u, s, v = torch.svd(X.T)
+                u, s, _ = torch.svd(X.T)
         self._basis = u.T
         self._singular_values = s
 

--- a/tests/test_blocks/test_pod.py
+++ b/tests/test_blocks/test_pod.py
@@ -23,6 +23,8 @@ def test_fit(rank, scale):
     assert pod._basis == None
     assert pod.basis == None
     assert pod._scaler == None
+    assert pod._singular_values == None
+    assert pod.singular_values == None
     assert pod.rank == rank
     assert pod.scale_coefficients == scale
 
@@ -37,6 +39,8 @@ def test_fit(rank, scale, randomized):
     dof = toy_snapshots.shape[1]
     assert pod.basis.shape == (rank, dof)
     assert pod._basis.shape == (n_snap, dof)
+    assert pod.singular_values.shape == (rank,)
+    assert pod._singular_values.shape == (n_snap,)
     if scale is True:
         assert pod._scaler["mean"].shape == (n_snap,)
         assert pod._scaler["std"].shape == (n_snap,)


### PR DESCRIPTION
## Description
This PR fixes #565 .
This PR adds the singular values as a property in `pina/model/block/pod_block.py`, and the related tests.

## Checklist

- [x] Code follows the project’s [Code Style Guidelines](https://github.com/mathLab/PINA/blob/master/CONTRIBUTING.md#code-style--guidelines)
- [x] Tests have been added or updated
- [x] Documentation has been updated if necessary
- [x] Pull request is linked to an open issue
