### PR TITLE
Remove Python 3.9 add Python 3.14

### DIFF
--- a/.github/workflows/monthly-tagger.yml
+++ b/.github/workflows/monthly-tagger.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13'] 
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14'] 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tutorial_exporter.yml
+++ b/.github/workflows/tutorial_exporter.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Install dependencies
       run: |
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Install dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "torch_geometric",
     "matplotlib",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 doc = [


### PR DESCRIPTION
## Description
This PR fixes #668

See: https://devguide.python.org/versions/#versions

--> Written by: @dario-coscia 
Regarding Dependencies, here the current situation:
| Package | py3.9 Dropped | Drop Date |
|----------|---------------|-----------|
| [torch](https://github.com/pytorch/pytorch) | [X] | September 22nd, 2025 |
| [lightning](https://github.com/Lightning-AI/lightning) | [ ] | ... |
| [torch_geometric](https://github.com/pyg-team/pytorch_geometric) | [X] | September 20th, 2025 |

## Checklist

- [x] Code follows the project’s [Code Style Guidelines](https://github.com/mathLab/PINA/blob/master/CONTRIBUTING.md#code-style--guidelines)
- [x] Tests have been added or updated
- [x] Documentation has been updated if necessary
- [x] Pull request is linked to an open issue
