### PR TITLE
Add workflow to create Git tags on demand

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,44 @@
+name: Create Git Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag name (eg. v1.3.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure git with PAT
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.PAT_PINA_PUSH }}@github.com/${{ github.repository }}.git"
+
+      - name: Check if the tag is already existing
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          git fetch --tags
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "❌ Tag $TAG already exists"
+            exit 1
+          fi
+
+      - name: Create and push the tag
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Description
This workflow allows users to create a Git tag via a manual trigger, checking for existing tags before creating a new one.

**I kept the `master` branch as base, let me know if you prefer on `dev`**

## Checklist

- [x] Code follows the project’s [Code Style Guidelines](https://github.com/mathLab/PINA/blob/master/CONTRIBUTING.md#code-style--guidelines)
- [x] Tests have been added or updated
- [x] Documentation has been updated if necessary
- [x] Pull request is linked to an open issue
